### PR TITLE
min api version

### DIFF
--- a/client/aci/client.go
+++ b/client/aci/client.go
@@ -14,7 +14,6 @@ import (
 const (
 	defaultUserAgent = "virtual-kubelet/azure-arm-aci/2021-07-01"
 	apiVersion       = "2021-07-01"
-	apiVersionForPriority = "2021-10-01"
 
 	containerGroupURLPath                    = "subscriptions/{{.subscriptionId}}/resourceGroups/{{.resourceGroup}}/providers/Microsoft.ContainerInstance/containerGroups/{{.containerGroupName}}"
 	containerGroupListURLPath                = "subscriptions/{{.subscriptionId}}/providers/Microsoft.ContainerInstance/containerGroups"

--- a/client/aci/client.go
+++ b/client/aci/client.go
@@ -14,6 +14,7 @@ import (
 const (
 	defaultUserAgent = "virtual-kubelet/azure-arm-aci/2021-07-01"
 	apiVersion       = "2021-07-01"
+	apiVersionForPriority = "2021-10-01"
 
 	containerGroupURLPath                    = "subscriptions/{{.subscriptionId}}/resourceGroups/{{.resourceGroup}}/providers/Microsoft.ContainerInstance/containerGroups/{{.containerGroupName}}"
 	containerGroupListURLPath                = "subscriptions/{{.subscriptionId}}/providers/Microsoft.ContainerInstance/containerGroups"

--- a/client/aci/create.go
+++ b/client/aci/create.go
@@ -20,6 +20,12 @@ func (c *Client) CreateContainerGroup(ctx context.Context, resourceGroup, contai
 		"api-version": []string{apiVersion},
 	}
 
+    priority, priorityExists := containerGroup.Tags["Priority"]
+    if priorityExists && len(priority) > 0 {
+	    urlParams = url.Values{
+		"api-version": []string{apiVersionForPriority},
+	    }
+    }
 	// Create the url.
 	uri := api.ResolveRelative(c.auth.ResourceManagerEndpoint, containerGroupURLPath)
 	uri += "?" + url.Values(urlParams).Encode()

--- a/client/aci/create.go
+++ b/client/aci/create.go
@@ -17,15 +17,9 @@ import (
 // From: https://docs.microsoft.com/en-us/rest/api/container-instances/containergroups/createorupdate
 func (c *Client) CreateContainerGroup(ctx context.Context, resourceGroup, containerGroupName string, containerGroup ContainerGroup) (*ContainerGroup, error) {
 	urlParams := url.Values{
-		"api-version": []string{apiVersion},
+		"api-version": []string{getAPIVersion(containerGroup, ctx)},
 	}
 
-    priority, priorityExists := containerGroup.Tags["Priority"]
-    if priorityExists && len(priority) > 0 {
-	    urlParams = url.Values{
-		"api-version": []string{apiVersionForPriority},
-	    }
-    }
 	// Create the url.
 	uri := api.ResolveRelative(c.auth.ResourceManagerEndpoint, containerGroupURLPath)
 	uri += "?" + url.Values(urlParams).Encode()

--- a/client/aci/create.go
+++ b/client/aci/create.go
@@ -17,7 +17,7 @@ import (
 // From: https://docs.microsoft.com/en-us/rest/api/container-instances/containergroups/createorupdate
 func (c *Client) CreateContainerGroup(ctx context.Context, resourceGroup, containerGroupName string, containerGroup ContainerGroup) (*ContainerGroup, error) {
 
-	// create a new VersionPRovider object
+	// create a new VersionProvider object
 	versionProvider := newVersionProvider(apiVersion)
 
 	urlParams := url.Values{

--- a/client/aci/create.go
+++ b/client/aci/create.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 
 	"github.com/virtual-kubelet/azure-aci/client/api"
-    "github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
 )
 
 // CreateContainerGroup creates a new Azure Container Instance with the
@@ -30,6 +30,7 @@ func (c *Client) CreateContainerGroup(ctx context.Context, resourceGroup, contai
 	uri := api.ResolveRelative(c.auth.ResourceManagerEndpoint, containerGroupURLPath)
 	uri += "?" + url.Values(urlParams).Encode()
 	log.G(ctx).Infof("Using url '%s' for Create", uri)
+
 	// Create the body for the request.
 	b := new(bytes.Buffer)
 	if err := json.NewEncoder(b).Encode(containerGroup); err != nil {

--- a/client/aci/create.go
+++ b/client/aci/create.go
@@ -16,8 +16,9 @@ import (
 // provided properties.
 // From: https://docs.microsoft.com/en-us/rest/api/container-instances/containergroups/createorupdate
 func (c *Client) CreateContainerGroup(ctx context.Context, resourceGroup, containerGroupName string, containerGroup ContainerGroup) (*ContainerGroup, error) {
+    versionProvider := newVersionProvider(apiVersion, ctx)
 	urlParams := url.Values{
-		"api-version": []string{getAPIVersion(containerGroup, ctx)},
+		"api-version": []string{versionProvider.getVersion(containerGroup).finalVersion},
 	}
 
 	// Create the url.

--- a/client/aci/create.go
+++ b/client/aci/create.go
@@ -16,9 +16,16 @@ import (
 // provided properties.
 // From: https://docs.microsoft.com/en-us/rest/api/container-instances/containergroups/createorupdate
 func (c *Client) CreateContainerGroup(ctx context.Context, resourceGroup, containerGroupName string, containerGroup ContainerGroup) (*ContainerGroup, error) {
-    versionProvider := newVersionProvider(apiVersion, ctx)
+
+	// create a new VersionProvider object
+	versionProvider, err := newVersionProvider(apiVersion)
+	if err != nil {
+		return nil, err
+	}
+
 	urlParams := url.Values{
-		"api-version": []string{versionProvider.getVersion(containerGroup).finalVersion},
+		// use versionProvider to get the correct min api version
+		"api-version": []string{versionProvider.getVersion(containerGroup, ctx).finalVersion},
 	}
 
 	// Create the url.

--- a/client/aci/create.go
+++ b/client/aci/create.go
@@ -16,9 +16,13 @@ import (
 // provided properties.
 // From: https://docs.microsoft.com/en-us/rest/api/container-instances/containergroups/createorupdate
 func (c *Client) CreateContainerGroup(ctx context.Context, resourceGroup, containerGroupName string, containerGroup ContainerGroup) (*ContainerGroup, error) {
-    versionProvider := newVersionProvider(apiVersion, ctx)
+
+	// create a new VersionPRovider object
+	versionProvider := newVersionProvider(apiVersion)
+
 	urlParams := url.Values{
-		"api-version": []string{versionProvider.getVersion(containerGroup).finalVersion},
+		// use versionProvider to get the correct min api version
+		"api-version": []string{versionProvider.getVersion(containerGroup, ctx).finalVersion},
 	}
 
 	// Create the url.

--- a/client/aci/create.go
+++ b/client/aci/create.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	"github.com/virtual-kubelet/azure-aci/client/api"
+    "github.com/virtual-kubelet/virtual-kubelet/log"
 )
 
 // CreateContainerGroup creates a new Azure Container Instance with the
@@ -28,7 +29,7 @@ func (c *Client) CreateContainerGroup(ctx context.Context, resourceGroup, contai
 	// Create the url.
 	uri := api.ResolveRelative(c.auth.ResourceManagerEndpoint, containerGroupURLPath)
 	uri += "?" + url.Values(urlParams).Encode()
-
+	log.G(ctx).Infof("Using url '%s' for Create", uri)
 	// Create the body for the request.
 	b := new(bytes.Buffer)
 	if err := json.NewEncoder(b).Encode(containerGroup); err != nil {

--- a/client/aci/create.go
+++ b/client/aci/create.go
@@ -16,16 +16,9 @@ import (
 // provided properties.
 // From: https://docs.microsoft.com/en-us/rest/api/container-instances/containergroups/createorupdate
 func (c *Client) CreateContainerGroup(ctx context.Context, resourceGroup, containerGroupName string, containerGroup ContainerGroup) (*ContainerGroup, error) {
-
-	// create a new VersionProvider object
-	versionProvider, err := newVersionProvider(apiVersion)
-	if err != nil {
-		return nil, err
-	}
-
+    versionProvider := newVersionProvider(apiVersion, ctx)
 	urlParams := url.Values{
-		// use versionProvider to get the correct min api version
-		"api-version": []string{versionProvider.getVersion(containerGroup, ctx).finalVersion},
+		"api-version": []string{versionProvider.getVersion(containerGroup).finalVersion},
 	}
 
 	// Create the url.

--- a/client/aci/versioning.go
+++ b/client/aci/versioning.go
@@ -3,7 +3,6 @@ package aci
 import (
     "github.com/virtual-kubelet/virtual-kubelet/log"
     "context"
-	"fmt"
 )
 
 //<summary>
@@ -47,14 +46,13 @@ func (versionProvider *VersionProvider) getVersion(containerGroup ContainerGroup
 
     versionProvider.setVersionFromProperty(string(containerGroup.ContainerGroupProperties.Priority), "Priority", ctx)
 
-	fmt.Printf("API Version set to %s \n", versionProvider.finalVersion)
     log.G(ctx).Infof("API Version set to %s \n", versionProvider.finalVersion)
-    return  versionProvider
+    return versionProvider
 }
 
 //<summary>
-// find the min api version for a string property based on the value in minVersionSupport map
-// assumes that the api version always uses the correct format YYYY-mm-dd[-suffix]
+//	find the min api version for a string property based on the value in minVersionSupport map
+//	assumes that the api version always uses the correct format YYYY-mm-dd[-suffix]
 //</summary>
 //<param name="property">the string value of some property field that should be checked<param>
 //<param name="keyRef">the key for the property in the minVersionSupport map</param>
@@ -67,7 +65,6 @@ func (versionProvider *VersionProvider) setVersionFromProperty(property string, 
     if len(property) > 0 && ok && versionProvider.finalVersion < minVersion {
         versionProvider.finalVersion = minVersion
     }
-	fmt.Printf("Selected API Version %s for property %s with value %s \n", versionProvider.finalVersion, keyRef, property)
     log.G(ctx).Infof("Selected API Version %s for property %s with value %s \n", versionProvider.finalVersion, keyRef, property)
     return versionProvider
 }

--- a/client/aci/versioning.go
+++ b/client/aci/versioning.go
@@ -1,0 +1,34 @@
+package aci
+
+import (
+    "github.com/virtual-kubelet/virtual-kubelet/log"
+    "context"
+)
+
+var minVersionSupport = map[string]string {
+    "Priority": "2021-10-01",
+}
+
+// CurrentAssumption: version is decided based on values in containerGroup.Tags
+// Set the minimum api version required based on the properties
+// find the minimum version for each of the tags, based on known values
+// find the max of the above min versions for each
+func getAPIVersion(containerGroup ContainerGroup, ctx context.Context) string {
+    finalApiVersion := apiVersion
+    for key, val := range containerGroup.Tags {
+        minVersion, ok := minVersionSupport[key]
+        if len(val) == 0 || !ok {
+            minVersion = apiVersion
+        }
+        if finalApiVersion < minVersion {
+            finalApiVersion = minVersion
+        }
+    }
+    log.G(ctx).Infof("setting api version to %s", finalApiVersion)
+    return finalApiVersion
+}
+
+
+// TODO:
+// pass podspec in create to allow for detailed versioning ??
+// maintain minVersionsSupport in an external json ??

--- a/client/aci/versioning.go
+++ b/client/aci/versioning.go
@@ -3,42 +3,71 @@ package aci
 import (
     "github.com/virtual-kubelet/virtual-kubelet/log"
     "context"
+	"fmt"
 )
 
-// map of minimum api version required for different properties
-// TODO: read from a separate json file if it gets too large
+//<summary>
+//	map of minimum api version required for different properties
+//	TODO: read from a separate json file if it gets too large
+//</summary>
 var minVersionSupport = map[string]string {
     "Priority": "2021-10-01",
 }
 
-// Basic object for selecting api version based on various properties
-// Maintains the api version selected after checking certain properties
+//<summary>
+//	VersionProvider struct for selecting api version based on various properties
+//	Maintains the api version selected after checking certain property
+//<summary>
 type VersionProvider struct {
     finalVersion string
 }
 
-// creates a new instance of VErsionProvider, and sets default version
-// assumes api version to be of the format YYYY-mm-dd[-suffix]
-// assumes that the api version format will not be violated
+//<summary>
+//	creates a new instance of VErsionProvider, and sets default version
+//	assumes api version to be of the format YYYY-mm-dd[-suffix]
+//	assumes that the api version format will not be violated
+//</summary>
+//<param name="defaultVersion"> The default api version </param>
+//<returns>
+//	reference to  an instance of the verison provider object
+//</returns>
 func newVersionProvider(defaultVersion string) (*VersionProvider) {
     return &VersionProvider{defaultVersion}
 }
 
-// returns the api version for the specific ContainerGroup instance based on various properties
+//<summary>
+//	get the api version for the specific ContainerGroup instance based on various properties
+//</summary>
+//<param name="containerGroup"> the ContainerGroup instance for which version is to be selected </param>
+//<param name="ctx"> the Context to be used for logging </param>
+//<returns>
+//	reference to an instance of VersionProvider with the finalVersion field updated
+//</returns>
 func (versionProvider *VersionProvider) getVersion(containerGroup ContainerGroup, ctx context.Context) (* VersionProvider) {
 
-    versionProvider.setVersionFromProperty(string(containerGroup.ContainerGroupProperties.Priority), "Priority")
+    versionProvider.setVersionFromProperty(string(containerGroup.ContainerGroupProperties.Priority), "Priority", ctx)
 
+	fmt.Printf("API Version set to %s \n", versionProvider.finalVersion)
     log.G(ctx).Infof("API Version set to %s \n", versionProvider.finalVersion)
     return  versionProvider
 }
 
+//<summary>
 // find the min api version for a string property based on the value in minVersionSupport map
 // assumes that the api version always uses the correct format YYYY-mm-dd[-suffix]
-func (versionProvider *VersionProvider) setVersionFromProperty(property string, keyRef string) (*VersionProvider) {
+//</summary>
+//<param name="property">the string value of some property field that should be checked<param>
+//<param name="keyRef">the key for the property in the minVersionSupport map</param>
+//<param name="ctx">the context to be used for logging</param>
+//<returns>
+//	reference to an instance of VersionProvider with the finalVersion field updated
+//</returns>
+func (versionProvider *VersionProvider) setVersionFromProperty(property string, keyRef string, ctx context.Context) (*VersionProvider) {
     minVersion, ok := minVersionSupport[keyRef]
     if len(property) > 0 && ok && versionProvider.finalVersion < minVersion {
         versionProvider.finalVersion = minVersion
     }
+	fmt.Printf("Selected API Version %s for property %s with value %s \n", versionProvider.finalVersion, keyRef, property)
+    log.G(ctx).Infof("Selected API Version %s for property %s with value %s \n", versionProvider.finalVersion, keyRef, property)
     return versionProvider
 }

--- a/client/aci/versioning.go
+++ b/client/aci/versioning.go
@@ -3,64 +3,40 @@ package aci
 import (
     "github.com/virtual-kubelet/virtual-kubelet/log"
     "context"
-    "regexp"
-    "fmt"
 )
 
-// map of minimum api versions required for different properties
-// TODO: read from a separate json file if it gets too large
 var minVersionSupport = map[string]string {
     "Priority": "2021-10-01",
 }
 
-// Basic object for selecting api version based on various properties
-// Maintains the api version selected after checking certain properties
 type VersionProvider struct {
     finalVersion string
+    ctx context.Context
 }
 
-// creates a new instance of VersionProvider, and sets the default version
-// assumes api version to be of the form YYYY-mm-dd
-// doesn't create an object with invalid version
-func newVersionProvider(defaultVersion string) (*VersionProvider, error) {
-    if res, _ := isValidVersion(defaultVersion); res {
-        return &VersionProvider{defaultVersion}, nil
-    }
-    return nil, fmt.Errorf("Version %s doesn't follow YYYY-mm-dd format", defaultVersion)
+func newVersionProvider(defaultVersion string, ctx context.Context) (*VersionProvider) {
+    return &VersionProvider{defaultVersion, ctx}
 }
 
-// returns the api version for the specific ContainerGroup instance based on verious properties
-func (versionProvider *VersionProvider) getVersion(containerGroup ContainerGroup, ctx context.Context) (* VersionProvider) {
+// call check version based on some property
+// return the version Provider with finalVersion updated 
+// keep adding more checks under this in future
+func (versionProvider *VersionProvider) getVersion(containerGroup ContainerGroup) (* VersionProvider) {
 
     versionProvider.setVersionFromProperty(string(containerGroup.ContainerGroupProperties.Priority), "Priority")
 
-    log.G(ctx).Infof("API Version set to %s \n", versionProvider.finalVersion)
-    return versionProvider
+    log.G(versionProvider.ctx).Infof("API Version set to %s \n", versionProvider.finalVersion)
+    return  versionProvider
 }
 
-// find the min api version for a string property based on the value in minVersionSupport map
-// don't update the api version unless the api version in map is valid
+// find the minimum version for a property from the map
 func (versionProvider *VersionProvider) setVersionFromProperty(property string, keyRef string) (*VersionProvider) {
     minVersion, ok := minVersionSupport[keyRef]
     if len(property) > 0 && ok && versionProvider.finalVersion < minVersion {
-        res, err := isValidVersion(minVersion)
-        if err == nil && res {
-            versionProvider.finalVersion = minVersion
-        }
+        versionProvider.finalVersion = minVersion
     }
     return versionProvider
 }
 
-// validate the format of version
-// assumes version is in YYYY-mm-dd format and hence sortable
-func isValidVersion(version string) (bool, error) {
-    exp := "[0-9]{4}-[0-9]{2}-[0-9]{2}"
-    res, err := regexp.MatchString(exp, version)
-    if err != nil {
-        return false, fmt.Errorf("Error validating version %s", version)
-    }
-    return res, nil
-}
-
-// TODO: PR
-// 1. add unit tests for getVersion and setVersionFromProperty
+// TODO:
+// maintain minVersionsSupport in an external json ??

--- a/client/aci/versioning.go
+++ b/client/aci/versioning.go
@@ -5,31 +5,36 @@ import (
     "context"
 )
 
+// map of minimum api version required for different properties
+// TODO: read from a separate json file if it gets too large
 var minVersionSupport = map[string]string {
     "Priority": "2021-10-01",
 }
 
+// Basic object for selecting api version based on various properties
+// Maintains the api version selected after checking certain properties
 type VersionProvider struct {
     finalVersion string
-    ctx context.Context
 }
 
-func newVersionProvider(defaultVersion string, ctx context.Context) (*VersionProvider) {
-    return &VersionProvider{defaultVersion, ctx}
+// creates a new instance of VErsionProvider, and sets default version
+// assumes api version to be of the format YYYY-mm-dd[-suffix]
+// assumes that the api version format will not be violated
+func newVersionProvider(defaultVersion string) (*VersionProvider) {
+    return &VersionProvider{defaultVersion}
 }
 
-// call check version based on some property
-// return the version Provider with finalVersion updated 
-// keep adding more checks under this in future
-func (versionProvider *VersionProvider) getVersion(containerGroup ContainerGroup) (* VersionProvider) {
+// returns the api version for the specific ContainerGroup instance based on various properties
+func (versionProvider *VersionProvider) getVersion(containerGroup ContainerGroup, ctx context.Context) (* VersionProvider) {
 
     versionProvider.setVersionFromProperty(string(containerGroup.ContainerGroupProperties.Priority), "Priority")
 
-    log.G(versionProvider.ctx).Infof("API Version set to %s \n", versionProvider.finalVersion)
+    log.G(ctx).Infof("API Version set to %s \n", versionProvider.finalVersion)
     return  versionProvider
 }
 
-// find the minimum version for a property from the map
+// find the min api version for a string property based on the value in minVersionSupport map
+// assumes that the api version always uses the correct format YYYY-mm-dd[-suffix]
 func (versionProvider *VersionProvider) setVersionFromProperty(property string, keyRef string) (*VersionProvider) {
     minVersion, ok := minVersionSupport[keyRef]
     if len(property) > 0 && ok && versionProvider.finalVersion < minVersion {
@@ -37,6 +42,3 @@ func (versionProvider *VersionProvider) setVersionFromProperty(property string, 
     }
     return versionProvider
 }
-
-// TODO:
-// maintain minVersionsSupport in an external json ??

--- a/client/aci/versioning.go
+++ b/client/aci/versioning.go
@@ -3,40 +3,64 @@ package aci
 import (
     "github.com/virtual-kubelet/virtual-kubelet/log"
     "context"
+    "regexp"
+    "fmt"
 )
 
+// map of minimum api versions required for different properties
+// TODO: read from a separate json file if it gets too large
 var minVersionSupport = map[string]string {
     "Priority": "2021-10-01",
 }
 
+// Basic object for selecting api version based on various properties
+// Maintains the api version selected after checking certain properties
 type VersionProvider struct {
     finalVersion string
-    ctx context.Context
 }
 
-func newVersionProvider(defaultVersion string, ctx context.Context) (*VersionProvider) {
-    return &VersionProvider{defaultVersion, ctx}
+// creates a new instance of VersionProvider, and sets the default version
+// assumes api version to be of the form YYYY-mm-dd
+// doesn't create an object with invalid version
+func newVersionProvider(defaultVersion string) (*VersionProvider, error) {
+    if res, _ := isValidVersion(defaultVersion); res {
+        return &VersionProvider{defaultVersion}, nil
+    }
+    return nil, fmt.Errorf("Version %s doesn't follow YYYY-mm-dd format", defaultVersion)
 }
 
-// call check version based on some property
-// return the version Provider with finalVersion updated 
-// keep adding more checks under this in future
-func (versionProvider *VersionProvider) getVersion(containerGroup ContainerGroup) (* VersionProvider) {
+// returns the api version for the specific ContainerGroup instance based on verious properties
+func (versionProvider *VersionProvider) getVersion(containerGroup ContainerGroup, ctx context.Context) (* VersionProvider) {
 
     versionProvider.setVersionFromProperty(string(containerGroup.ContainerGroupProperties.Priority), "Priority")
 
-    log.G(versionProvider.ctx).Infof("API Version set to %s \n", versionProvider.finalVersion)
-    return  versionProvider
+    log.G(ctx).Infof("API Version set to %s \n", versionProvider.finalVersion)
+    return versionProvider
 }
 
-// find the minimum version for a property from the map
+// find the min api version for a string property based on the value in minVersionSupport map
+// don't update the api version unless the api version in map is valid
 func (versionProvider *VersionProvider) setVersionFromProperty(property string, keyRef string) (*VersionProvider) {
     minVersion, ok := minVersionSupport[keyRef]
     if len(property) > 0 && ok && versionProvider.finalVersion < minVersion {
-        versionProvider.finalVersion = minVersion
+        res, err := isValidVersion(minVersion)
+        if err == nil && res {
+            versionProvider.finalVersion = minVersion
+        }
     }
     return versionProvider
 }
 
-// TODO:
-// maintain minVersionsSupport in an external json ??
+// validate the format of version
+// assumes version is in YYYY-mm-dd format and hence sortable
+func isValidVersion(version string) (bool, error) {
+    exp := "[0-9]{4}-[0-9]{2}-[0-9]{2}"
+    res, err := regexp.MatchString(exp, version)
+    if err != nil {
+        return false, fmt.Errorf("Error validating version %s", version)
+    }
+    return res, nil
+}
+
+// TODO: PR
+// 1. add unit tests for getVersion and setVersionFromProperty

--- a/client/aci/versioning_test.go
+++ b/client/aci/versioning_test.go
@@ -14,15 +14,15 @@ func TestSetVersionFromPropertyInMap(t *testing.T) {
 	versionProvider:= newVersionProvider(defaultVersion)
 
 	// should use defualt version when property is not populated
-	versionProvider.setVersionFromProperty("", key)
+	versionProvider.setVersionFromProperty("", key, context.Background())
 	assert.Check(t, is.Equal(versionProvider.finalVersion, defaultVersion), "Default version should be used when a property value is empty")
 
 	// should use api version present in map if priority is Spot
-	versionProvider.setVersionFromProperty("Spot", key)
+	versionProvider.setVersionFromProperty("Spot", key, context.Background())
 	assert.Check(t, is.Equal(versionProvider.finalVersion, minVersionSupport[key]), "When a version is available for the property in map, the final version should be >= min api version for the property")
 
 	// should use api version present in map if priority is Regular
-	versionProvider.setVersionFromProperty("Regular", key)
+	versionProvider.setVersionFromProperty("Regular", key, context.Background())
 	assert.Check(t, is.Equal(versionProvider.finalVersion, minVersionSupport[key]), "When a version is available for the property in map, the final version should be >= min api version for the property")
 
 }
@@ -34,7 +34,7 @@ func TestSetLowerVersionFromPropertyInMap (t *testing.T) {
 	versionProvider := newVersionProvider(largeDefaultVersion)
 
 	// should use largeDefaultVersion as it is > the min api version for thiis key
-	versionProvider.setVersionFromProperty("Regular", key)
+	versionProvider.setVersionFromProperty("Regular", key, context.Background())
 	assert.Check(t, versionProvider.finalVersion >= minVersionSupport[key], "Use larger version among default and min api versions for various properties")
 }
 
@@ -45,7 +45,7 @@ func TestSetVersionFromPropertyNotInMap(t *testing.T) {
 	versionProvider:= newVersionProvider(defaultVersion)
 
 	// should use default version when property is not present in map
-	versionProvider.setVersionFromProperty("propertyValue", key)
+	versionProvider.setVersionFromProperty("propertyValue", key, context.Background())
 	assert.Check(t, versionProvider.finalVersion == defaultVersion, "Default version should be used when no version for a property is available in map")
 }
 

--- a/client/aci/versioning_test.go
+++ b/client/aci/versioning_test.go
@@ -1,0 +1,85 @@
+package aci
+
+import (
+	"testing"
+	"context"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+// tests setlecting version when property is present in map
+func TestSetVersionFromPropertyInMap(t *testing.T) {
+	key := "Priority"
+	defaultVersion := apiVersion
+	versionProvider:= newVersionProvider(defaultVersion)
+
+	// should use defualt version when property is not populated
+	versionProvider.setVersionFromProperty("", key)
+	assert.Check(t, is.Equal(versionProvider.finalVersion, defaultVersion), "Default version should be used when a property value is empty")
+
+	// should use api version present in map if priority is Spot
+	versionProvider.setVersionFromProperty("Spot", key)
+	assert.Check(t, is.Equal(versionProvider.finalVersion, minVersionSupport[key]), "When a version is available for the property in map, the final version should be >= min api version for the property")
+
+	// should use api version present in map if priority is Regular
+	versionProvider.setVersionFromProperty("Regular", key)
+	assert.Check(t, is.Equal(versionProvider.finalVersion, minVersionSupport[key]), "When a version is available for the property in map, the final version should be >= min api version for the property")
+
+}
+
+// tests selecting version when a property is present in map with version < defualtVersion
+func TestSetLowerVersionFromPropertyInMap (t *testing.T) {
+	key := "Priority"
+	largeDefaultVersion := "9999-99-99"
+	versionProvider := newVersionProvider(largeDefaultVersion)
+
+	// should use largeDefaultVersion as it is > the min api version for thiis key
+	versionProvider.setVersionFromProperty("Regular", key)
+	assert.Check(t, versionProvider.finalVersion >= minVersionSupport[key], "Use larger version among default and min api versions for various properties")
+}
+
+// test selecting version when property is not present in map
+func TestSetVersionFromPropertyNotInMap(t *testing.T) {
+	key := "someUnknownKey"
+	defaultVersion := apiVersion
+	versionProvider:= newVersionProvider(defaultVersion)
+
+	// should use default version when property is not present in map
+	versionProvider.setVersionFromProperty("propertyValue", key)
+	assert.Check(t, versionProvider.finalVersion == defaultVersion, "Default version should be used when no version for a property is available in map")
+}
+
+// test getVersion for ContainerGroup with Priority
+func TestGetVersionForContainerGroupWithPriority(t *testing.T) {
+	key := "Priority"
+	versionProvider := newVersionProvider(apiVersion)
+	containerGroup := ContainerGroup{
+		Location: "eastus",
+		ContainerGroupProperties: ContainerGroupProperties{
+			Priority: Spot,
+			OsType: Linux,
+		},
+	}
+
+	// should use api version in map when priority is set for a containerGroup
+	versionProvider.getVersion(containerGroup, context.Background())
+	assert.Check(t, is.Equal(versionProvider.finalVersion, minVersionSupport[key]), "Use api version in map when priority is set for a containerGroup")
+
+}
+
+// test getVersion for containerGroup without Priority
+func TestGetVersionForContainerGroupWithoutPriority(t *testing.T) {
+	defaultVersion := apiVersion
+	versionProvider := newVersionProvider(defaultVersion)
+	containerGroup := ContainerGroup{
+		Location: "eastus",
+		ContainerGroupProperties: ContainerGroupProperties{
+			OsType: Linux,
+		},
+	}
+
+	// should use default api version when priority is not set for a containerGroup
+	versionProvider.getVersion(containerGroup, context.Background())
+	assert.Check(t, is.Equal(versionProvider.finalVersion, defaultVersion), "Use default api version when priority is not set for a containerGroup")
+
+}

--- a/provider/aci.go
+++ b/provider/aci.go
@@ -739,7 +739,7 @@ func (p *ACIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 }
 
 // Set the Container Group Priority Property
-// value is set based on the priorityTypeAnnotation field under anotations in the pod spec
+// value is set based on the priorityTypeAnnotation field under annotations in the pod spec
 // Accepted Values : Regular, Spot
 func setContainerGroupPriority(containerGroup *aci.ContainerGroup, pod *v1.Pod) error {
 

--- a/provider/aci.go
+++ b/provider/aci.go
@@ -62,7 +62,7 @@ const (
 )
 
 const (
-	priorityTypeAnnotation = "priority"
+	priorityTypeAnnotation = "virtual-kubelet.io/priority"
 )
 
 const (
@@ -739,6 +739,7 @@ func (p *ACIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 }
 
 // Set the Container Group Priority Property
+// value is set based on the priorityTypeAnnotation field under anotations in the pod spec
 // Accepted Values : Regular, Spot
 func setContainerGroupPriority(containerGroup *aci.ContainerGroup, pod *v1.Pod) error {
 

--- a/provider/aci.go
+++ b/provider/aci.go
@@ -63,6 +63,7 @@ const (
 
 const (
 	priorityTypeAnnotation = "virtual-kubelet.io/priority"
+	priorityTagName	       = "virtual-kubelet.io-priority"
 )
 
 const (
@@ -743,7 +744,6 @@ func (p *ACIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 // Accepted Values : Regular, Spot
 func setContainerGroupPriority(containerGroup *aci.ContainerGroup, pod *v1.Pod) error {
 
-	priorityTagName := "virtual-kubelet.io-priority"
 	if pod.Annotations != nil {
 		priority, priorityExists := pod.Annotations[priorityTypeAnnotation]
 		if priorityExists {
@@ -761,7 +761,6 @@ func setContainerGroupPriority(containerGroup *aci.ContainerGroup, pod *v1.Pod) 
 
 	return nil
 }
-
 
 func (p *ACIProvider) createContainerGroup(ctx context.Context, podNS, podName string, cg *aci.ContainerGroup) error {
 	ctx, span := trace.StartSpan(ctx, "aci.createContainerGroup")

--- a/provider/aci.go
+++ b/provider/aci.go
@@ -725,7 +725,7 @@ func (p *ACIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 		"Namespace":         pod.Namespace,
 		"UID":               podUID,
 		"CreationTimestamp": podCreationTimestamp,
-		"Priority":          pod.Annotations[priorityTypeAnnotation],
+		"virtual-kubelet.io-priority": pod.Annotations[priorityTypeAnnotation],
 	}
 
 	p.amendVnetResources(&containerGroup, pod)

--- a/provider/aci_test.go
+++ b/provider/aci_test.go
@@ -131,7 +131,7 @@ func TestCreatePodWithoutResourceSpec(t *testing.T) {
 		assert.Check(t, is.Equal(1.5, cg.ContainerGroupProperties.Containers[0].Resources.Requests.MemoryInGB), "Request Memory is not expected")
 		assert.Check(t, is.Nil(cg.ContainerGroupProperties.Containers[0].Resources.Limits), "Limits should be nil")
 
-		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		priorityTag, ok := cg.Tags[priorityTagName]
 		assert.Check(t, is.Equal(ok, false), "Priority tag should not be set")
 		assert.Check(t, is.Equal("", priorityTag), "Container Group Priority should not be set")
 
@@ -419,7 +419,7 @@ func TestCreatePodWithSpotPriority(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Spot, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
-		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		priorityTag, ok := cg.Tags[priorityTagName]
 		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
 		assert.Check(t, is.Equal(string(aci.Spot), priorityTag), "Container Group Priority Tag does not match")
 
@@ -508,7 +508,7 @@ func TestCreatePodWithSpotPriorityIgnoreCase(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Spot, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
-		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		priorityTag, ok := cg.Tags[priorityTagName]
 		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
 		assert.Check(t, is.Equal(string(aci.Spot), priorityTag), "Container Group Priority Tag does not match")
 
@@ -597,7 +597,7 @@ func TestCreatePodWithRegularPriority(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Regular, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
-		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		priorityTag, ok := cg.Tags[priorityTagName]
 		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
 		assert.Check(t, is.Equal(string(aci.Regular), priorityTag), "Container Group Priority Tag does not match")
 

--- a/provider/aci_test.go
+++ b/provider/aci_test.go
@@ -131,6 +131,10 @@ func TestCreatePodWithoutResourceSpec(t *testing.T) {
 		assert.Check(t, is.Equal(1.5, cg.ContainerGroupProperties.Containers[0].Resources.Requests.MemoryInGB), "Request Memory is not expected")
 		assert.Check(t, is.Nil(cg.ContainerGroupProperties.Containers[0].Resources.Limits), "Limits should be nil")
 
+		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		assert.Check(t, is.Equal(ok, false), "Priority tag should not be set")
+		assert.Check(t, is.Equal("", priorityTag), "Container Group Priority should not be set")
+
 		return http.StatusOK, cg
 	}
 
@@ -415,6 +419,10 @@ func TestCreatePodWithSpotPriority(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Spot, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
+		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
+		assert.Check(t, is.Equal(string(aci.Spot), priorityTag), "Container Group Priority Tag does not match")
+
 		return http.StatusOK, cg
 	}
 
@@ -500,6 +508,10 @@ func TestCreatePodWithSpotPriorityIgnoreCase(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Spot, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
+		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
+		assert.Check(t, is.Equal(string(aci.Spot), priorityTag), "Container Group Priority Tag does not match")
+
 		return http.StatusOK, cg
 	}
 
@@ -584,6 +596,10 @@ func TestCreatePodWithRegularPriority(t *testing.T) {
 		assert.Check(t, is.Equal(int32(1), cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.Count), "Requests GPU Count is not expected")
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Regular, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
+
+		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
+		assert.Check(t, is.Equal(string(aci.Regular), priorityTag), "Container Group Priority Tag does not match")
 
 		return http.StatusOK, cg
 	}


### PR DESCRIPTION
- Currently setting min api version based on Tags set on containers
- Allows min api version for various Tags to be set
- Defaults to `aci.apiVersion`

### API version selected in running unit tests:
![image](https://user-images.githubusercontent.com/102992687/166960434-5458b058-bc54-4ede-accd-e11479ca4c98.png)

### Creating Virtual Node using helm on aks
```
helm install "$RELEASE_NAME" "$CHART_URL" \ 
  --set provider=azure \ 
  --set rbac.install=true \ 
  --set enableAuthenticationTokenWebhook=false \ 
  --set providers.azure.targetAKS=true \ 
  --set providers.azure.clientId=$AZURE_CLIENT_ID \ 
  --set providers.azure.clientKey=$AZURE_CLIENT_SECRET \ 
  --set providers.azure.masterUri=$MASTER_URI \ 
  --set providers.azure.aciResourceGroup=$AZURE_RG \ 
  --set providers.azure.aciRegion=$ACI_REGION \ 
  --set providers.azure.tenantId=$AZURE_TENANT_ID \ 
  --set providers.azure.subscriptionId=$AZURE_SUBSCRIPTION_ID \ 
  --set nodeName=$NODE_NAME \ 
  --set image.repository=docker.io \ 
  --set image.name=fnuarnav/virtual-kubelet \ 
  --set image.tag=minApiVersion
```
#### Using tag name `virtual-kubelet.io-priority` and setting accepted priority values in tags
![image](https://user-images.githubusercontent.com/102992687/167475306-1775d7eb-188c-4ef8-9f67-3f50aae64a3c.png)
![image](https://user-images.githubusercontent.com/102992687/167475466-7e134f94-ec7a-4c27-a7fb-55c44a61ca82.png)

### Kusto logs 
`scope: @armprod/ARMProd`
```
HttpIncomingRequests
| where TIMESTAMP > datetime("2022-05-09 19:00:00")
| where subscriptionId == "ec9fcd04-e188-48b9-abfc-a35d515f1836"
| where targetUri contains "default-arnav-hello-min-api-version-priority"
| where httpMethod in ("PUT", "POST")
| project PreciseTimeStamp, TaskName, subscriptionId, principalOid,  operationName, httpMethod, targetUri, userAgent, apiVersion, targetResourceType
| limit 10
```

<html>
<body>
<!--StartFragment--><div><br/><br/>

PreciseTimeStamp | TaskName | subscriptionId | principalOid | operationName | httpMethod | targetUri | userAgent | apiVersion | targetResourceType
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
2022-05-09T19:00:18.5727649Z | HttpIncomingRequestStart | ec9fcd04-e188-48b9-abfc-a35d515f1836 |   | PUT/SUBSCRIPTIONS/RESOURCEGROUPS/PROVIDERS/MICROSOFT.CONTAINERINSTANCE/CONTAINERGROUPS/ | PUT | https://management.azure.com:443/subscriptions/ec9fcd04-e188-48b9-abfc-a35d515f1836/resourceGroups/aci-virtual-node-test/providers/Microsoft.ContainerInstance/containerGroups/default-arnav-hello-min-api-version-priority-regular?api-version=2021-10-01 | virtual-kubelet/azure-arm-aci/2021-07-01 helm-chart/aks/virtual-kubelet-aci-for-aks/1.4.0 | 2021-10-01 | CONTAINERGROUPS
2022-05-09T19:00:20.5407053Z | HttpIncomingRequestEndWithSuccess | ec9fcd04-e188-48b9-abfc-a35d515f1836 | c1c2e6ca-8e9c-4eb0-9c56-21afc3c81afb | PUT/SUBSCRIPTIONS/RESOURCEGROUPS/PROVIDERS/MICROSOFT.CONTAINERINSTANCE/CONTAINERGROUPS/ | PUT | https://management.azure.com:443/subscriptions/ec9fcd04-e188-48b9-abfc-a35d515f1836/resourceGroups/aci-virtual-node-test/providers/Microsoft.ContainerInstance/containerGroups/default-arnav-hello-min-api-version-priority-regular?api-version=2021-10-01 | virtual-kubelet/azure-arm-aci/2021-07-01 helm-chart/aks/virtual-kubelet-aci-for-aks/1.4.0 | 2021-10-01 | CONTAINERGROUPS
2022-05-09T19:15:51.2365493Z | HttpIncomingRequestStart | ec9fcd04-e188-48b9-abfc-a35d515f1836 |   | PUT/SUBSCRIPTIONS/RESOURCEGROUPS/PROVIDERS/MICROSOFT.CONTAINERINSTANCE/CONTAINERGROUPS/ | PUT | https://management.azure.com:443/subscriptions/ec9fcd04-e188-48b9-abfc-a35d515f1836/resourceGroups/aci-virtual-node-test/providers/Microsoft.ContainerInstance/containerGroups/default-arnav-hello-min-api-version-priority-spot?api-version=2021-10-01 | virtual-kubelet/azure-arm-aci/2021-07-01 helm-chart/aks/virtual-kubelet-aci-for-aks/1.4.0 | 2021-10-01 | CONTAINERGROUPS
2022-05-09T19:15:53.2124325Z | HttpIncomingRequestEndWithSuccess | ec9fcd04-e188-48b9-abfc-a35d515f1836 | c1c2e6ca-8e9c-4eb0-9c56-21afc3c81afb | PUT/SUBSCRIPTIONS/RESOURCEGROUPS/PROVIDERS/MICROSOFT.CONTAINERINSTANCE/CONTAINERGROUPS/ | PUT | https://management.azure.com:443/subscriptions/ec9fcd04-e188-48b9-abfc-a35d515f1836/resourceGroups/aci-virtual-node-test/providers/Microsoft.ContainerInstance/containerGroups/default-arnav-hello-min-api-version-priority-spot?api-version=2021-10-01 | virtual-kubelet/azure-arm-aci/2021-07-01 helm-chart/aks/virtual-kubelet-aci-for-aks/1.4.0 | 2021-10-01 | CONTAINERGROUPS
2022-05-09T19:26:43.2747873Z | HttpIncomingRequestStart | ec9fcd04-e188-48b9-abfc-a35d515f1836 |   | PUT/SUBSCRIPTIONS/RESOURCEGROUPS/PROVIDERS/MICROSOFT.CONTAINERINSTANCE/CONTAINERGROUPS/ | PUT | https://management.azure.com:443/subscriptions/ec9fcd04-e188-48b9-abfc-a35d515f1836/resourceGroups/aci-virtual-node-test/providers/Microsoft.ContainerInstance/containerGroups/default-arnav-hello-min-api-version-priority-not-set?api-version=2021-07-01 | virtual-kubelet/azure-arm-aci/2021-07-01 helm-chart/aks/virtual-kubelet-aci-for-aks/1.4.0 | 2021-07-01 | CONTAINERGROUPS
2022-05-09T19:26:45.2033148Z | HttpIncomingRequestEndWithSuccess | ec9fcd04-e188-48b9-abfc-a35d515f1836 | c1c2e6ca-8e9c-4eb0-9c56-21afc3c81afb | PUT/SUBSCRIPTIONS/RESOURCEGROUPS/PROVIDERS/MICROSOFT.CONTAINERINSTANCE/CONTAINERGROUPS/ | PUT | https://management.azure.com:443/subscriptions/ec9fcd04-e188-48b9-abfc-a35d515f1836/resourceGroups/aci-virtual-node-test/providers/Microsoft.ContainerInstance/containerGroups/default-arnav-hello-min-api-version-priority-not-set?api-version=2021-07-01 | virtual-kubelet/azure-arm-aci/2021-07-01 helm-chart/aks/virtual-kubelet-aci-for-aks/1.4.0 | 2021-07-01 | CONTAINERGROUPS

</div><!--EndFragment-->
</body>
</html>

Note: API version `2021-10-01` is used when priority is set 