### PR TITLE
addressing review comments

### DIFF
--- a/provider/aci.go
+++ b/provider/aci.go
@@ -739,7 +739,7 @@ func (p *ACIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 }
 
 // Set the Container Group Priority Property
-// value is set based on the priorityTypeAnnotation field under anotations in the pod spec
+// value is set based on the priorityTypeAnnotation field under annotations in the pod spec
 // Accepted Values : Regular, Spot
 func setContainerGroupPriority(containerGroup *aci.ContainerGroup, pod *v1.Pod) error {
 

--- a/provider/aci.go
+++ b/provider/aci.go
@@ -62,7 +62,7 @@ const (
 )
 
 const (
-	priorityTypeAnnotation = "priority"
+	priorityTypeAnnotation = "virtual-kubelet.io/priority"
 )
 
 const (
@@ -739,6 +739,7 @@ func (p *ACIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 }
 
 // Set the Container Group Priority Property
+// value is set based on the priorityTypeAnnotation field under anotations in the pod spec
 // Accepted Values : Regular, Spot
 func setContainerGroupPriority(containerGroup *aci.ContainerGroup, pod *v1.Pod) error {
 

--- a/provider/aci.go
+++ b/provider/aci.go
@@ -63,6 +63,7 @@ const (
 
 const (
 	priorityTypeAnnotation = "virtual-kubelet.io/priority"
+	priorityTagName	       = "virtual-kubelet.io-priority"
 )
 
 const (
@@ -743,7 +744,6 @@ func (p *ACIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 // Accepted Values : Regular, Spot
 func setContainerGroupPriority(containerGroup *aci.ContainerGroup, pod *v1.Pod) error {
 
-	priorityTagName := "virtual-kubelet.io-priority"
 	if pod.Annotations != nil {
 		priority, priorityExists := pod.Annotations[priorityTypeAnnotation]
 		if priorityExists {
@@ -761,7 +761,6 @@ func setContainerGroupPriority(containerGroup *aci.ContainerGroup, pod *v1.Pod) 
 
 	return nil
 }
-
 
 func (p *ACIProvider) createContainerGroup(ctx context.Context, podNS, podName string, cg *aci.ContainerGroup) error {
 	ctx, span := trace.StartSpan(ctx, "aci.createContainerGroup")

--- a/provider/aci.go
+++ b/provider/aci.go
@@ -725,7 +725,7 @@ func (p *ACIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 		"Namespace":         pod.Namespace,
 		"UID":               podUID,
 		"CreationTimestamp": podCreationTimestamp,
-		"Priority":          pod.Annotations[priorityTypeAnnotation],
+		"virtual-kubelet.io-priority": pod.Annotations[priorityTypeAnnotation],
 	}
 
 	p.amendVnetResources(&containerGroup, pod)

--- a/provider/aci_test.go
+++ b/provider/aci_test.go
@@ -131,7 +131,7 @@ func TestCreatePodWithoutResourceSpec(t *testing.T) {
 		assert.Check(t, is.Equal(1.5, cg.ContainerGroupProperties.Containers[0].Resources.Requests.MemoryInGB), "Request Memory is not expected")
 		assert.Check(t, is.Nil(cg.ContainerGroupProperties.Containers[0].Resources.Limits), "Limits should be nil")
 
-		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		priorityTag, ok := cg.Tags[priorityTagName]
 		assert.Check(t, is.Equal(ok, false), "Priority tag should not be set")
 		assert.Check(t, is.Equal("", priorityTag), "Container Group Priority should not be set")
 
@@ -419,7 +419,7 @@ func TestCreatePodWithSpotPriority(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Spot, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
-		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		priorityTag, ok := cg.Tags[priorityTagName]
 		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
 		assert.Check(t, is.Equal(string(aci.Spot), priorityTag), "Container Group Priority Tag does not match")
 
@@ -508,7 +508,7 @@ func TestCreatePodWithSpotPriorityIgnoreCase(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Spot, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
-		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		priorityTag, ok := cg.Tags[priorityTagName]
 		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
 		assert.Check(t, is.Equal(string(aci.Spot), priorityTag), "Container Group Priority Tag does not match")
 
@@ -597,7 +597,7 @@ func TestCreatePodWithRegularPriority(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Regular, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
-		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		priorityTag, ok := cg.Tags[priorityTagName]
 		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
 		assert.Check(t, is.Equal(string(aci.Regular), priorityTag), "Container Group Priority Tag does not match")
 

--- a/provider/aci_test.go
+++ b/provider/aci_test.go
@@ -131,6 +131,10 @@ func TestCreatePodWithoutResourceSpec(t *testing.T) {
 		assert.Check(t, is.Equal(1.5, cg.ContainerGroupProperties.Containers[0].Resources.Requests.MemoryInGB), "Request Memory is not expected")
 		assert.Check(t, is.Nil(cg.ContainerGroupProperties.Containers[0].Resources.Limits), "Limits should be nil")
 
+		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		assert.Check(t, is.Equal(ok, false), "Priority tag should not be set")
+		assert.Check(t, is.Equal("", priorityTag), "Container Group Priority should not be set")
+
 		return http.StatusOK, cg
 	}
 
@@ -415,6 +419,10 @@ func TestCreatePodWithSpotPriority(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Spot, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
+		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
+		assert.Check(t, is.Equal(string(aci.Spot), priorityTag), "Container Group Priority Tag does not match")
+
 		return http.StatusOK, cg
 	}
 
@@ -500,6 +508,10 @@ func TestCreatePodWithSpotPriorityIgnoreCase(t *testing.T) {
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Spot, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
 
+		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
+		assert.Check(t, is.Equal(string(aci.Spot), priorityTag), "Container Group Priority Tag does not match")
+
 		return http.StatusOK, cg
 	}
 
@@ -584,6 +596,10 @@ func TestCreatePodWithRegularPriority(t *testing.T) {
 		assert.Check(t, is.Equal(int32(1), cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.Count), "Requests GPU Count is not expected")
 		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
 		assert.Check(t, is.Equal(aci.Regular, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
+
+		priorityTag, ok := cg.Tags["virtual-kubelet.io-priority"]
+		assert.Check(t, is.Equal(ok, true), "Priority tag was not set")
+		assert.Check(t, is.Equal(string(aci.Regular), priorityTag), "Container Group Priority Tag does not match")
 
 		return http.StatusOK, cg
 	}


### PR DESCRIPTION
- using `virtual-kubelet.io/priority` as annotation key for priority
- updated comment to show that priority is set from annotations
- use tag name `virtual-kubelet.io-priority` for priority tag

### Testing on AKS
```
# Linux Virtual Node 
helm install "$RELEASE_NAME" "$CHART_URL" \ 
  --set provider=azure \ 
  --set rbac.install=true \ 
  --set enableAuthenticationTokenWebhook=false \ 
  --set providers.azure.targetAKS=true \ 
  --set providers.azure.clientId=$AZURE_CLIENT_ID \ 
  --set providers.azure.clientKey=$AZURE_CLIENT_SECRET \ 
  --set providers.azure.masterUri=$MASTER_URI \ 
  --set providers.azure.aciResourceGroup=$AZURE_RG \ 
  --set providers.azure.aciRegion=$ACI_REGION \ 
  --set providers.azure.tenantId=$AZURE_TENANT_ID \ 
  --set providers.azure.subscriptionId=$AZURE_SUBSCRIPTION_ID \ 
  --set nodeName=$NODE_NAME \ 
  --set image.repository=docker.io \ 
  --set image.name=fnuarnav/virtual-kubelet-test \ 
  --set image.tag=tejalReview
```

![image](https://user-images.githubusercontent.com/102992687/167229586-8430ae9a-73de-4e3a-af73-3591fefdf874.png)

![image](https://user-images.githubusercontent.com/102992687/167229548-d98ebeca-3c25-428f-af7f-defcbc6ff192.png)

Note: Priority tag is populated with accepted value `Spot` even though Priority annotation is passed in lowercase in the pod spec